### PR TITLE
Add support for related ManyToMany fields

### DIFF
--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -300,6 +300,20 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
             ):
                 many_to_one_or_one_to_many_fields.append(f)
 
+            elif all([f.many_to_many, f.name in self._clone_many_to_many_fields,]):
+                many_to_many_fields.append(f)
+
+            elif all(
+                [
+                    f.many_to_many,
+                    not self._clone_many_to_many_fields,
+                    self._clone_excluded_many_to_many_fields,
+                    f not in many_to_many_fields,
+                    f.name not in self._clone_excluded_many_to_many_fields,
+                ]
+            ):
+                many_to_many_fields.append(f)
+
         for f in self._meta.many_to_many:
             if not sub_clone:
                 if f.name in self._clone_many_to_many_fields:
@@ -343,27 +357,27 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
 
         # Clone many to many fields
         for field in many_to_many_fields:
-            if all(
-                [
-                    field.remote_field.through,
-                    not field.remote_field.through._meta.auto_created,
-                ]
-            ):
-                objs = field.remote_field.through.objects.filter(
-                    **{field.m2m_field_name(): self.pk}
-                )
-                for item in objs:
-                    if hasattr(field.remote_field.through, "make_clone"):
-                        item.make_clone(
-                            attrs={field.m2m_field_name(): duplicate}, sub_clone=True
-                        )
-                    else:
-                        item.pk = None
-                        setattr(item, field.m2m_field_name(), duplicate)
-                        item.save()
+            if hasattr(field, "field"):
+                # ManyToManyRel
+                field_name = field.field.m2m_reverse_field_name()
+                through = field.through
+                source = getattr(self, field.related_name)
+                destination = getattr(duplicate, field.related_name)
             else:
+                through = field.remote_field.through
+                field_name = field.m2m_field_name()
                 source = getattr(self, field.attname)
                 destination = getattr(duplicate, field.attname)
+            if all([through, not through._meta.auto_created,]):
+                objs = through.objects.filter(**{field_name: self.pk})
+                for item in objs:
+                    if hasattr(through, "make_clone"):
+                        item.make_clone(attrs={field_name: duplicate}, sub_clone=True)
+                    else:
+                        item.pk = None
+                        setattr(item, field_name, duplicate)
+                        item.save()
+            else:
                 destination.set(source.all())
         return duplicate
 

--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -305,7 +305,12 @@ class CloneMixin(object):
             ):
                 many_to_one_or_one_to_many_fields.append(f)
 
-            elif all([f.many_to_many, f.name in self._clone_many_to_many_fields,]):
+            elif all(
+                [
+                    f.many_to_many,
+                    f.name in self._clone_many_to_many_fields,
+                ]
+            ):
                 many_to_many_fields.append(f)
 
             elif all(
@@ -377,7 +382,12 @@ class CloneMixin(object):
                 field_name = field.m2m_field_name()
                 source = getattr(self, field.attname)
                 destination = getattr(duplicate, field.attname)
-            if all([through, not through._meta.auto_created,]):
+            if all(
+                [
+                    through,
+                    not through._meta.auto_created,
+                ]
+            ):
                 objs = through.objects.filter(**{field_name: self.pk})
                 for item in objs:
                     if hasattr(through, "make_clone"):

--- a/model_clone/tests.py
+++ b/model_clone/tests.py
@@ -98,6 +98,27 @@ class CloneMixinTestCase(TestCase):
             list(book.authors.values_list("first_name", "last_name")),
             list(book_clone.authors.values_list("first_name", "last_name")),
         )
+
+    @patch("sample.models.Author._clone_many_to_many_fields", new_callable=PropertyMock)
+    def test_cloning_with_explicit_related__clone_many_to_many_fields(
+        self, _clone_many_to_many_fields_mock,
+    ):
+        author = Author.objects.create(
+            first_name="Opubo", last_name="Jack", age=24, sex="F", created_by=self.user
+        )
+
+        _clone_many_to_many_fields_mock.return_value = ["books"]
+
+        book_1 = Book.objects.create(name="New Book 1", created_by=self.user)
+        book_2 = Book.objects.create(name="New Book 2", created_by=self.user)
+        author.books.set([book_1, book_2])
+
+        author_clone = author.make_clone()
+
+        self.assertEqual(
+            list(author.books.values_list("name")),
+            list(author_clone.books.values_list("name")),
+        )
         _clone_many_to_many_fields_mock.assert_called_once()
 
     def test_cloning_unique_fields_is_valid(self):

--- a/model_clone/tests.py
+++ b/model_clone/tests.py
@@ -106,7 +106,8 @@ class CloneMixinTestCase(TestCase):
 
     @patch("sample.models.Author._clone_many_to_many_fields", new_callable=PropertyMock)
     def test_cloning_with_explicit_related__clone_many_to_many_fields(
-        self, _clone_many_to_many_fields_mock,
+        self,
+        _clone_many_to_many_fields_mock,
     ):
         author = Author.objects.create(
             first_name="Opubo", last_name="Jack", age=24, sex="F", created_by=self.user


### PR DESCRIPTION
`_clone_many_to_many_fields` now could be used for both many to many and related fields:
```python
class Author(CloneModel):
    first_name = models.CharField(max_length=200, unique=True)
    last_name = models.CharField(max_length=200)

class Book(CloneModel):
    name = models.CharField(max_length=2000)
    authors = models.ManyToManyField(Author, related_name="books")

    _clone_many_to_many_fields = ["authors"]
```
or
```python
class Author(CloneModel):
    first_name = models.CharField(max_length=200, unique=True)
    last_name = models.CharField(max_length=200)

    _clone_many_to_many_fields = ["books"]

class Book(CloneModel):
    name = models.CharField(max_length=2000)
    authors = models.ManyToManyField(Author, related_name="books")
```
