### PR TITLE
Add support for related ManyToMany fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     branches:
       - master
   pull_request_target:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
+      - feature/*
+      - '**'
   pull_request_target:
     branches: 
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
         make install-dev
     - name: Run Lint
       uses: samuelmeuli/lint-action@v1
-      continue-on-error: true
       with:
         github_token: ${{ secrets.github_token }}
         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         pip install -U pip
         make install-dev
     - name: Run Lint
-      uses: wearerequired/lint-action@feature/pull_request_target
+      uses: wearerequired/lint-action@v1.6.0
       with:
         github_token: ${{ secrets.github_token }}
         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,15 @@ jobs:
       run: |
         pip install -U pip
         make install-dev
-    - name: Run Lint
-      uses: wearerequired/lint-action@feature/pull_request_target
-      if: ${{ github.event_name != 'pull_request_target' }}
-      with:
-        github_token: ${{ secrets.github_token }}
-        black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
-        flake8: true
-        git_email: "lint-action@django-clone.com"
-        auto_fix: true
+#     - name: Run Lint
+#       uses: wearerequired/lint-action@feature/pull_request_target
+#       if: ${{ github.event_name != 'pull_request_target' }}
+#       with:
+#         github_token: ${{ secrets.github_token }}
+#         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
+#         flake8: true
+#         git_email: "lint-action@django-clone.com"
+#         auto_fix: true
     - name: Test
       run: make tox
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         make install-dev
     - name: Run Lint
       uses: samuelmeuli/lint-action@v1
+      continue-on-error: true
       with:
         github_token: ${{ secrets.github_token }}
         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 
@@ -51,7 +51,7 @@ jobs:
         pip install -U pip
         make install-dev
     - name: Run Lint
-      uses: samuelmeuli/lint-action@v1
+      uses: wearerequired/lint-action@feature/pull_request_target
       with:
         github_token: ${{ secrets.github_token }}
         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         pip install -U pip
         make install-dev
     - name: Run Lint
-      uses: wearerequired/lint-action@v1.6.0
+      uses: wearerequired/lint-action@feature/pull_request_target
       with:
         github_token: ${{ secrets.github_token }}
         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,13 @@ jobs:
         make install-dev
     - name: Run Lint
       uses: wearerequired/lint-action@feature/pull_request_target
+      if: ${{ github.event_name != 'pull_request_target' }}
       with:
         github_token: ${{ secrets.github_token }}
         black: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
         flake8: true
         git_email: "lint-action@django-clone.com"
-        auto_fix: ${{ github.event_name != 'pull_request_target' }}
+        auto_fix: true
     - name: Test
       run: make tox
       env:

--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -300,6 +300,20 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
             ):
                 many_to_one_or_one_to_many_fields.append(f)
 
+            elif all([f.many_to_many, f.name in self._clone_many_to_many_fields,]):
+                many_to_many_fields.append(f)
+
+            elif all(
+                [
+                    f.many_to_many,
+                    not self._clone_many_to_many_fields,
+                    self._clone_excluded_many_to_many_fields,
+                    f not in many_to_many_fields,
+                    f.name not in self._clone_excluded_many_to_many_fields,
+                ]
+            ):
+                many_to_many_fields.append(f)
+
         for f in self._meta.many_to_many:
             if not sub_clone:
                 if f.name in self._clone_many_to_many_fields:
@@ -343,27 +357,27 @@ class CloneMixin(six.with_metaclass(CloneMetaClass)):
 
         # Clone many to many fields
         for field in many_to_many_fields:
-            if all(
-                [
-                    field.remote_field.through,
-                    not field.remote_field.through._meta.auto_created,
-                ]
-            ):
-                objs = field.remote_field.through.objects.filter(
-                    **{field.m2m_field_name(): self.pk}
-                )
-                for item in objs:
-                    if hasattr(field.remote_field.through, "make_clone"):
-                        item.make_clone(
-                            attrs={field.m2m_field_name(): duplicate}, sub_clone=True
-                        )
-                    else:
-                        item.pk = None
-                        setattr(item, field.m2m_field_name(), duplicate)
-                        item.save()
+            if hasattr(field, "field"):
+                # ManyToManyRel
+                field_name = field.field.m2m_reverse_field_name()
+                through = field.through
+                source = getattr(self, field.related_name)
+                destination = getattr(duplicate, field.related_name)
             else:
+                through = field.remote_field.through
+                field_name = field.m2m_field_name()
                 source = getattr(self, field.attname)
                 destination = getattr(duplicate, field.attname)
+            if all([through, not through._meta.auto_created,]):
+                objs = through.objects.filter(**{field_name: self.pk})
+                for item in objs:
+                    if hasattr(through, "make_clone"):
+                        item.make_clone(attrs={field_name: duplicate}, sub_clone=True)
+                    else:
+                        item.pk = None
+                        setattr(item, field_name, duplicate)
+                        item.save()
+            else:
                 destination.set(source.all())
         return duplicate
 

--- a/model_clone/mixins/clone.py
+++ b/model_clone/mixins/clone.py
@@ -305,7 +305,12 @@ class CloneMixin(object):
             ):
                 many_to_one_or_one_to_many_fields.append(f)
 
-            elif all([f.many_to_many, f.name in self._clone_many_to_many_fields,]):
+            elif all(
+                [
+                    f.many_to_many,
+                    f.name in self._clone_many_to_many_fields,
+                ]
+            ):
                 many_to_many_fields.append(f)
 
             elif all(
@@ -377,7 +382,12 @@ class CloneMixin(object):
                 field_name = field.m2m_field_name()
                 source = getattr(self, field.attname)
                 destination = getattr(duplicate, field.attname)
-            if all([through, not through._meta.auto_created,]):
+            if all(
+                [
+                    through,
+                    not through._meta.auto_created,
+                ]
+            ):
                 objs = through.objects.filter(**{field_name: self.pk})
                 for item in objs:
                     if hasattr(through, "make_clone"):

--- a/model_clone/tests.py
+++ b/model_clone/tests.py
@@ -98,6 +98,27 @@ class CloneMixinTestCase(TestCase):
             list(book.authors.values_list("first_name", "last_name")),
             list(book_clone.authors.values_list("first_name", "last_name")),
         )
+
+    @patch("sample.models.Author._clone_many_to_many_fields", new_callable=PropertyMock)
+    def test_cloning_with_explicit_related__clone_many_to_many_fields(
+        self, _clone_many_to_many_fields_mock,
+    ):
+        author = Author.objects.create(
+            first_name="Opubo", last_name="Jack", age=24, sex="F", created_by=self.user
+        )
+
+        _clone_many_to_many_fields_mock.return_value = ["books"]
+
+        book_1 = Book.objects.create(name="New Book 1", created_by=self.user)
+        book_2 = Book.objects.create(name="New Book 2", created_by=self.user)
+        author.books.set([book_1, book_2])
+
+        author_clone = author.make_clone()
+
+        self.assertEqual(
+            list(author.books.values_list("name")),
+            list(author_clone.books.values_list("name")),
+        )
         _clone_many_to_many_fields_mock.assert_called_once()
 
     def test_cloning_unique_fields_is_valid(self):

--- a/model_clone/tests.py
+++ b/model_clone/tests.py
@@ -106,7 +106,8 @@ class CloneMixinTestCase(TestCase):
 
     @patch("sample.models.Author._clone_many_to_many_fields", new_callable=PropertyMock)
     def test_cloning_with_explicit_related__clone_many_to_many_fields(
-        self, _clone_many_to_many_fields_mock,
+        self,
+        _clone_many_to_many_fields_mock,
     ):
         author = Author.objects.create(
             first_name="Opubo", last_name="Jack", age=24, sex="F", created_by=self.user


### PR DESCRIPTION
`_clone_many_to_many_fields` now could be used for both many to many and related fields:
```python
class Author(CloneModel):
    books = models.ManyToManyField(Author, related_name="authors")

class Book(CloneModel):
    _clone_many_to_many_fields = ["authors"]

author = Author()
book1 = Book()

book2 = book1.make_clone()

# before this PR:
author.books.all() => [book1]

# after merging this PR:
author.books.all() => [book1, book2]
```
Without this PR, if you want to clone the book in above example, you have to:
```python
book2 = book1.make_clone()
author.books.add(book2)
```
