### PR TITLE
Add pre and post clone save signals

### DIFF
--- a/model_clone/signals.py
+++ b/model_clone/signals.py
@@ -1,0 +1,4 @@
+from django.db.models.signals import ModelSignal
+
+pre_clone_save = ModelSignal(use_caching=True)
+post_clone_save = ModelSignal(use_caching=True)

--- a/model_clone/tests/test_clone_signals.py
+++ b/model_clone/tests/test_clone_signals.py
@@ -1,0 +1,38 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from django.utils.text import slugify
+
+from sample.models import Book, Edition
+
+User = get_user_model()
+
+
+class CloneSignalsTestCase(TestCase):
+    REPLICA_DB_ALIAS = "replica"
+    databases = {
+        "default",
+        "replica",
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(username="user")
+
+    def test_signals(self):
+        name = "New Book"
+        first_published_at = timezone.datetime(
+            1970, 1, 1, tzinfo=timezone.get_default_timezone()
+        )
+        book = Book.objects.create(
+            name=name,
+            created_by=self.user,
+            slug=slugify(name),
+            published_at=first_published_at,
+        )
+        assert book.published_at == first_published_at
+        edition = Edition.objects.create(seq=1, book=book)
+        cloned_edition = edition.make_clone()
+        assert cloned_edition.seq == 2
+        book.refresh_from_db()
+        assert book.published_at != first_published_at

--- a/model_clone/tests/test_clone_signals.py
+++ b/model_clone/tests/test_clone_signals.py
@@ -30,9 +30,9 @@ class CloneSignalsTestCase(TestCase):
             slug=slugify(name),
             published_at=first_published_at,
         )
-        assert book.published_at == first_published_at
+        self.assertEqual(book.published_at, first_published_at)
         edition = Edition.objects.create(seq=1, book=book)
         cloned_edition = edition.make_clone()
-        assert cloned_edition.seq == 2
+        self.assertEqual(cloned_edition.seq, 2)
         book.refresh_from_db()
-        assert book.published_at != first_published_at
+        self.assertNotEqual(book.published_at, first_published_at)

--- a/sample/__init__.py
+++ b/sample/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "sample.apps.SampleConfig"

--- a/sample/apps.py
+++ b/sample/apps.py
@@ -7,4 +7,4 @@ class SampleConfig(AppConfig):
     name = "sample"
 
     def ready(self):
-        from . import signals # noqa: F401
+        from . import signals  # noqa: F401

--- a/sample/apps.py
+++ b/sample/apps.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-import
 from django.apps import AppConfig
 
 
@@ -6,4 +7,4 @@ class SampleConfig(AppConfig):
     name = "sample"
 
     def ready(self):
-        from . import signals
+        from . import signals # noqa: F401

--- a/sample/apps.py
+++ b/sample/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class SampleConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "sample"
+
+    def ready(self):
+        from . import signals

--- a/sample/signals.py
+++ b/sample/signals.py
@@ -1,0 +1,18 @@
+from django.dispatch import receiver
+from django.utils import timezone
+
+from model_clone.signals import post_clone_save, pre_clone_save
+
+from .models import Edition
+
+
+@receiver(pre_clone_save, sender=Edition)
+def increase_seq(sender, instance, **kwargs):
+    instance.seq += 1
+
+
+@receiver(post_clone_save, sender=Edition)
+def update_book_published_at(sender, instance, **kwargs):
+    if instance.book:
+        instance.book.published_at = timezone.now()
+        instance.book.save(update_fields=["published_at"])


### PR DESCRIPTION
So we could potentially get rid of `pre_save_duplicate` and keep flexible.
Also removed [the 2nd](https://github.com/tj-django/django-clone/blob/main/model_clone/mixin.py#L242) `save()` since we've moved `__duplicate_m2o_fields` [before saving.](https://github.com/tj-django/django-clone/pull/673/files#diff-d0baea420a048f681fc043c89c3ec153a5c632e4b4eda9ad4428b57fb2bfb2e9R235-L237)