### PR TITLE
Add Python 3.11 in testing and refine uploading Codecov reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: true
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-beta.1']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
 
     steps:
       - uses: actions/checkout@v3.1.0
@@ -53,7 +53,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: "Upload coverage to Codecov"
-        if: ${{ runner.os }} == "Linux"
+        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.9' }}
         uses: codecov/codecov-action@v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
+        exclude:
+          - platform: macos-latest
+            python-version: 3.11
+          - platform: windows-latest
+            python-version: 3.11
 
     steps:
       - uses: actions/checkout@v3.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,20 @@ skipsdist = false
 envlist =
     py36-django{20,21,22,30,31,32,main}-{linux,macos,windows}
     py37-django{20,21,22,30,31,32,main}-{linux,macos,windows}
-    py38-django{20,21,22,30,31,32,40,41,main}-{linux,macos,windows}
-    py39-django{20,21,22,30,31,32,40,41,main}-{linux,macos,windows}
-    py310-django{21,22,30,31,32,40,41,main}-{linux,macos,windows}
+    py38-django{21,22,30,31,32,40,41,main}-{linux,macos,windows}
+    py39-django{21,22,30,31,32,40,41,main}-{linux,macos,windows}
+    py310-django{22,30,31,32,40,41,main}-{linux,macos,windows}
+    py311-django{22,30,31,32,40,41,main}-{linux,macos,windows}
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 PLATFORM =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     py38-django{21,22,30,31,32,40,41,main}-{linux,macos,windows}
     py39-django{21,22,30,31,32,40,41,main}-{linux,macos,windows}
     py310-django{22,30,31,32,40,41,main}-{linux,macos,windows}
-    py311-django{22,30,31,32,40,41,main}-{linux,macos,windows}
+    py311-django{22,30,31,32,40,41,main}-{linux}
 skip_missing_interpreters = true
 
 [gh-actions]


### PR DESCRIPTION
- Added Python 3.11 env in actions and tox, but since [lxml has no wheels ready for MacOS and Windows](https://pypi.org/project/lxml/#files), I just excluded them.
- Fixed the condition of uploading reports to Codecov.
- Removed some old Django versions since they did not officially support higher Python versions.