### PR TITLE
Fix cache path issue for multiple platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v3.0.11
-        id: pip-cache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          cache: 'pip'
+          cache-dependency-path: '**/requirements.txt'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
For MacOS and Windows, the default pip cache directories are different so we shouldn't hard code it.