### PR TITLE
Actually save the m2m on the destination for Wagtail/ClusterableModel

### DIFF
--- a/model_clone/mixin.py
+++ b/model_clone/mixin.py
@@ -718,6 +718,8 @@ class CloneMixin(object):
         :return: The duplicate instance objects from all the many-to-many fields duplicated.
         """
 
+        changed = False
+
         for field in self._meta.many_to_many:
             if all(
                 [
@@ -729,5 +731,9 @@ class CloneMixin(object):
                 source = getattr(self, field.attname)
                 destination = getattr(duplicate, field.attname)
                 destination.set(list(source.all()))
+                changed = True
+
+        if changed:
+            duplicate.save()
 
         return duplicate


### PR DESCRIPTION
Discovered this while testing the setting for `_clone_linked_m2m_fields`.

In my case, without the `duplicate.save()`, the values were not persisted to the database.

This was using Wagtail's `ClusterableModel`, so it's possible that's causing the issue.

But I checked multiple times and I I query the through table before the `.save()` and after, there is a difference.

I'm not sure what a better fix would be.